### PR TITLE
fix: hide getMode from public repo interface

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -29,7 +29,6 @@ export interface RepositoryInterface extends EventEmitter {
   getToggles(): FeatureInterface[];
   getTogglesWithSegmentData(): EnhancedFeatureInterface[];
   getSegment(id: number): Segment | undefined;
-  getMode(): Mode;
   stop(): void;
   start(): Promise<void>;
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We don't need getMode in public interface for now. Impl method is enough for testing and it doesn't break Unleash usage contract for other repo impls based on the interface

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
