### PR TITLE
feat: sdk/client driven sdk mode change

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -31,7 +31,7 @@ export interface RepositoryInterface extends EventEmitter {
   getSegment(id: number): Segment | undefined;
   stop(): void;
   start(): Promise<void>;
-  setMode(mode: 'polling' | 'streaming'): Promise<void>;
+  setMode?(mode: 'polling' | 'streaming'): Promise<void>;
 }
 
 export interface RepositoryOptions {

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -31,6 +31,7 @@ export interface RepositoryInterface extends EventEmitter {
   getSegment(id: number): Segment | undefined;
   stop(): void;
   start(): Promise<void>;
+  setMode(mode: 'polling' | 'streaming'): Promise<void>;
 }
 
 export interface RepositoryOptions {
@@ -174,13 +175,8 @@ export default class Repository extends EventEmitter implements EventEmitter {
 
   private async handleModeChange(event: { data: string }) {
     try {
-      const newMode = event.data;
-
-      if (newMode === 'polling' && this.mode.type === 'streaming') {
-        await this.switchToPolling();
-      } else if (newMode === 'streaming' && this.mode.type === 'polling') {
-        await this.switchToStreaming();
-      }
+      const newMode = event.data as 'polling' | 'streaming';
+      await this.setMode(newMode);
     } catch (err) {
       this.emit(UnleashEvents.Error, new Error(`Failed to handle mode change: ${err}`));
     }
@@ -597,6 +593,24 @@ Message: ${err.message}`,
 
   getMode(): Mode {
     return this.mode;
+  }
+
+  async setMode(mode: 'polling' | 'streaming'): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
+    const currentMode = this.mode;
+
+    if (currentMode.type === mode) {
+      return;
+    }
+
+    if (mode === 'polling' && currentMode.type === 'streaming') {
+      await this.switchToPolling();
+    } else if (mode === 'streaming' && currentMode.type === 'polling') {
+      await this.switchToStreaming();
+    }
   }
 
   private enhanceStrategies = (

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -379,6 +379,9 @@ export class Unleash extends EventEmitter {
    * @param mode The new mode to switch to ('polling' or 'streaming')
    */
   async setExperimentalMode(mode: 'polling' | 'streaming'): Promise<void> {
-    return this.repository.setMode(mode);
+    if (this.repository.setMode) {
+      return this.repository.setMode(mode);
+    }
+    throw new Error('setMode is not supported by this repository implementation');
   }
 }

--- a/src/unleash.ts
+++ b/src/unleash.ts
@@ -373,4 +373,12 @@ export class Unleash extends EventEmitter {
     await this.flushMetrics();
     this.destroy();
   }
+
+  /**
+   * Experimental: Change the fetching mode at runtime
+   * @param mode The new mode to switch to ('polling' or 'streaming')
+   */
+  async setExperimentalMode(mode: 'polling' | 'streaming'): Promise<void> {
+    return this.repository.setMode(mode);
+  }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Previously we added server-driven SDK mode change (https://github.com/Unleash/unleash-node-sdk/pull/758). However we can also do much simpler client/SDK driven runtime mode change.

You can set setExerimentalMode on SDK instance and it will switch automatically. This allows us to control mode per SDK client (safer internal rollout)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
