### PR TITLE
chore: ignore yarn scripts

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v6
         with:
@@ -33,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v6
         with:
@@ -55,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,7 +22,9 @@ jobs:
           node-version: ${{matrix.node-version}}
           cache: yarn
       - name: Yarn
-        run: yarn
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
       - name: Test
         run: yarn lint && yarn test
 
@@ -37,7 +39,7 @@ jobs:
           node-version: 22.x
           cache: yarn
       - name: Yarn
-        run: yarn
+        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn coverage
       - name: Coveralls
@@ -59,7 +61,9 @@ jobs:
           node-version: 20.x
           cache: yarn
       - name: Yarn
-        run: yarn
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
       - name: Pack SDK tarball
         run: |
           SDK_TARBALL="$(npm pack --silent --ignore-scripts | tail -n 1)"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn run pre-commit
+lint-staged

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,7 @@
+# Supply-chain hardening: never run dependency lifecycle scripts
+# (preinstall/install/postinstall) during yarn install.
+# Side effect: our own `prepare` script (husky + build) is also skipped on
+# install — run `yarn prepare` once after cloning.
+# Publishing is unaffected — `npm publish` reads .npmrc, not this file, so
+# `prepare` still builds lib/ during a release.
+ignore-scripts true

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Clone the repository and install dependencies:
 git clone https://github.com/Unleash/unleash-node-sdk.git
 cd unleash-node-sdk
 yarn install
+yarn prepare
 ```
+
+`yarn prepare` sets up git hooks and builds the project. It doesn't run automatically on install because dependency lifecycle scripts are disabled (see `.yarnrc`) as a supply-chain hardening measure.
 
 The [client specification](https://github.com/Unleash/client-specification) test data is included as a dev dependency (`@unleash/client-specification`). It defines a shared contract that all Unleash SDKs test against.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }

--- a/scripts/test-package/run.sh
+++ b/scripts/test-package/run.sh
@@ -26,7 +26,7 @@ cat <<EOF > "$TEST_DIR/package.json"
 }
 EOF
 cd "$TEST_DIR"
-npm install --install-links
+npm install --install-links --ignore-scripts
 mkdir src
 echo -e "import { Unleash } from 'unleash-client';\nvoid Unleash;\nconsole.log('Hello world');" > src/index.ts
 ./node_modules/.bin/tsc -b tsconfig.json


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

  Dependency install scripts are disabled (ignore-scripts true in .yarnrc). This is the main payload vector in recent attacks. The one postinstall in our tree (esbuild, via vitest) is safe to skip: its binary ships in a platform-specific package, verified working.

  Side effect: yarn 1 can't disable dependency scripts without also disabling our own prepare (husky + build), so:
  - CI jobs get explicit yarn build steps. Previously lib/ was built implicitly by install, and without this test-as-dependency would pack a tarball missing lib/
  - the README tells contributors to run yarn prepare after cloning

  CI now uses --frozen-lockfile. Plain yarn silently accepted lockfile drift. The release template already had this right.

  Renovate waits 7 days before proposing new releases (minimumReleaseAge). Compromised versions are typically removed within hours to days.

  The pre-commit hook calls lint-staged directly instead of via yarn. Husky puts node_modules/.bin on the hook's PATH, so it works regardless of a contributor's package/node manager setup.

  Publishing is unaffected: npm publish reads .npmrc, not .yarnrc, so prepare still builds lib/ at release time.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
