### PR TITLE
chore(deps): bump re2js to ^2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "make-fetch-happen": "^15.0.3",
     "murmurhash3js": "^3.0.1",
     "proxy-from-env": "^1.1.0",
-    "re2js": "^1.2.2",
+    "re2js": "^2.3.2",
     "semver": "^7.7.3"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,10 +1651,10 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-re2js@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/re2js/-/re2js-1.2.2.tgz#6609181fdcd45369e9a3b3aeaa8e9e527e49cdf2"
-  integrity sha512-xvy4uuynAZWg9SuHbg0lgQncOuK6wssLmbHs8L8+YRbWLKY8Pe1avaHjNaFLOjErq8Oh0HvwQRWqIOCRL7uDDw==
+re2js@^2.3.2:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-2.8.6.tgz#acbd17a1ad0e98c1f2ee0a2adc17ba0903d9ca95"
+  integrity sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==
 
 redis@^4.6.7:
   version "4.6.14"


### PR DESCRIPTION
## What

Bump `re2js` from `^1.2.2` to `^2.3.2`.

## Why

The SDK is the only thing still on `re2js` 1.x. `unleash-server` already depends on `re2js@2.3.2`, so any consumer that pulls in **both** the SDK and the server resolves two major versions of `re2js` and loads **two full copies of the RE2 engine** into memory. A heap snapshot of a live Unleash Cloud pod showed the re2js source present twice (~0.6–1.3 MB of duplicated string + compiled code per process).

Aligning the SDK on 2.x lets those consumers dedupe to a single copy.
