### PR TITLE
feat: improve performance of user list search

### DIFF
--- a/src/strategy/user-with-id-strategy.ts
+++ b/src/strategy/user-with-id-strategy.ts
@@ -2,25 +2,25 @@ import type { Context } from '../context';
 import { Strategy } from './strategy';
 
 export default class UserWithIdStrategy extends Strategy {
-  private readonly userIdSets = new WeakMap<{ userIds?: string }, Set<string>>();
+  private readonly cache = new WeakMap<
+    { userIds?: string },
+    { userIds: string; ids: Set<string> }
+  >();
 
   constructor() {
     super('userWithId');
   }
 
   isEnabled(parameters: { userIds?: string }, context: Context) {
-    if (
-      typeof parameters.userIds !== 'string' ||
-      parameters.userIds === '' ||
-      context.userId === undefined
-    ) {
+    const { userIds } = parameters;
+    if (typeof userIds !== 'string' || userIds === '' || context.userId === undefined) {
       return false;
     }
-    let userIdList = this.userIdSets.get(parameters);
-    if (!userIdList) {
-      userIdList = new Set(parameters.userIds.split(/\s*,\s*/));
-      this.userIdSets.set(parameters, userIdList);
+    let cached = this.cache.get(parameters);
+    if (cached?.userIds !== userIds) {
+      cached = { userIds, ids: new Set(userIds.split(/\s*,\s*/)) };
+      this.cache.set(parameters, cached);
     }
-    return userIdList.has(context.userId);
+    return cached.ids.has(context.userId);
   }
 }

--- a/src/strategy/user-with-id-strategy.ts
+++ b/src/strategy/user-with-id-strategy.ts
@@ -2,12 +2,28 @@ import type { Context } from '../context';
 import { Strategy } from './strategy';
 
 export default class UserWithIdStrategy extends Strategy {
+  private readonly userIdSets = new WeakMap<
+    { userIds?: string },
+    Set<string>
+  >();
+
   constructor() {
     super('userWithId');
   }
 
   isEnabled(parameters: { userIds?: string }, context: Context) {
-    const userIdList = parameters.userIds ? parameters.userIds.split(/\s*,\s*/) : [];
-    return context.userId !== undefined && userIdList.includes(context.userId);
+    if (
+      typeof parameters.userIds !== 'string' ||
+      parameters.userIds === '' ||
+      context.userId == undefined
+    ) {
+      return false;
+    }
+    let userIdList = this.userIdSets.get(parameters);
+    if (!userIdList) {
+      userIdList = new Set(parameters.userIds.split(/\s*,\s*/));
+      this.userIdSets.set(parameters, userIdList);
+    }
+    return userIdList.has(context.userId);
   }
 }

--- a/src/strategy/user-with-id-strategy.ts
+++ b/src/strategy/user-with-id-strategy.ts
@@ -2,10 +2,7 @@ import type { Context } from '../context';
 import { Strategy } from './strategy';
 
 export default class UserWithIdStrategy extends Strategy {
-  private readonly userIdSets = new WeakMap<
-    { userIds?: string },
-    Set<string>
-  >();
+  private readonly userIdSets = new WeakMap<{ userIds?: string }, Set<string>>();
 
   constructor() {
     super('userWithId');
@@ -15,7 +12,7 @@ export default class UserWithIdStrategy extends Strategy {
     if (
       typeof parameters.userIds !== 'string' ||
       parameters.userIds === '' ||
-      context.userId == undefined
+      context.userId === undefined
     ) {
       return false;
     }

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import Client from '../client';
 import { UnleashEvents } from '../events';
 import { defaultStrategies, Strategy } from '../strategy';
@@ -434,4 +434,29 @@ test('should return disabled variant for non-matching strategy variant', () => {
     feature_enabled: false,
     featureEnabled: false,
   });
+});
+
+test('should preserve strategy parameters reference and cache parsed userIds across isEnabled calls', () => {
+  const toggle = buildToggle('feature-user-list', true, [
+    {
+      name: 'userWithId',
+      parameters: {
+        userIds: '123, 456, 789',
+      },
+    },
+  ]);
+  const repo = {
+    getToggle() {
+      return toggle;
+    },
+  };
+  const client = new Client(repo, defaultStrategies);
+  const splitSpy = vi.spyOn(String.prototype, 'split');
+
+  expect(client.isEnabled('feature-user-list', { userId: '123' })).toBe(true);
+  expect(client.isEnabled('feature-user-list', { userId: '456' })).toBe(true);
+  expect(client.isEnabled('feature-user-list', { userId: '999' })).toBe(false);
+
+  expect(splitSpy).toHaveBeenCalledTimes(1);
+  splitSpy.mockRestore();
 });

--- a/src/test/strategy/user-with-id-strategy.test.ts
+++ b/src/test/strategy/user-with-id-strategy.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import UserWithIdStrategy from '../../strategy/user-with-id-strategy';
 
@@ -34,4 +34,17 @@ test('user-with-id-strategy should be enabled for userId in list', () => {
   const params = { userIds: '123,122,12312312' };
   const context = { userId: '122' };
   expect(strategy.isEnabled(params, context)).toBe(true);
+});
+
+test('user-with-id-strategy should cache parsed userIds for same parameters reference', () => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123, 122, 12312312' };
+  const splitSpy = vi.spyOn(String.prototype, 'split');
+
+  expect(strategy.isEnabled(params, { userId: '123' })).toBe(true);
+  expect(strategy.isEnabled(params, { userId: '122' })).toBe(true);
+  expect(strategy.isEnabled(params, { userId: '999' })).toBe(false);
+
+  expect(splitSpy).toHaveBeenCalledTimes(1);
+  splitSpy.mockRestore();
 });

--- a/src/test/strategy/user-with-id-strategy.test.ts
+++ b/src/test/strategy/user-with-id-strategy.test.ts
@@ -48,3 +48,15 @@ test('user-with-id-strategy should cache parsed userIds for same parameters refe
   expect(splitSpy).toHaveBeenCalledTimes(1);
   splitSpy.mockRestore();
 });
+
+test('rebuilds the cache when userIds changes', () => {
+  const strategy = new UserWithIdStrategy();
+  const params = { userIds: '123' };
+
+  expect(strategy.isEnabled(params, { userId: '123' })).toBe(true);
+
+  params.userIds = '456';
+
+  expect(strategy.isEnabled(params, { userId: '456' })).toBe(true);
+  expect(strategy.isEnabled(params, { userId: '123' })).toBe(false);
+});


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Thank you for this awesome library!

In practice it's very common to store huge user lists in feature flags, and when the total number grows, the performance drops. By storing user ids in a Set and using parameters a key to WeakMap, I'm getting a significant speedup in synthetic benchmark:

```
ids   speedup
10    19x
100   155x
1000  1738x
```

The Set survives every poll and is rebuilt only when the flag config actually changes